### PR TITLE
evaluate_model_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # probeye changelog
 
+## 1.0.10 (2021-Nov-10)
+### Changed
+- the evaluate_model_response method was moved from InferenceProblem to the solver classes
+### Added
+- added integration test for maximum likelihood estimation with uninformative priors
+
 ## 1.0.9 (2021-Nov-09)
 ### Changed
 - deep-copying the inference problem in the solver classes is wrapped with try/except, since not all problems can be deepcopied

--- a/probeye/definition/forward_model.py
+++ b/probeye/definition/forward_model.py
@@ -101,36 +101,7 @@ class ForwardModelBase:
 
     def __call__(self, inp):
         """
-        Evaluates the forward model either via calling the original or the
-        wrapped response method, depending on the current definition of the
-        call-method. This method is equivalent to calling self.response as long
-        as the call-method was not overwritten. If it was overwritten, however,
-        this method (the __call__-method) makes sure, that the returned value
-        has the same format as the returned value by the response-method. See
-        self.response for a docstring on its parameters/return values.
-        """
-        res_ori = self.call(inp)
-        if type(res_ori) is dict:
-            # in this case it is assumed that res_ori is the dictionary returned
-            # by the response-method
-            res = res_ori
-        else:
-            # in this case, the returned value is assumed to be a numeric vector
-            # which needs to be translated back to the dictionary structure
-            res = self.response_structure
-            i = 0
-            for key in self.response_structure.keys():
-                n_numbers = self.response_structure[key]
-                res[key] = res_ori[i:i + n_numbers]
-                i += n_numbers
-        return res
-
-    def call(self, inp):
-        """
-        This function can be used by inference engines to wrap the forward
-        model's response. This can be done by overwriting this method by one
-        that might do something before and after calling self.response(inp).
-        See self.response for a docstring on its parameters/return values.
+        Calls the self.response method. Shortens internal forward model calls.
         """
         return self.response(inp)
 

--- a/probeye/definition/inference_problem.py
+++ b/probeye/definition/inference_problem.py
@@ -808,62 +808,6 @@ class InferenceProblem:
         # under the given forward model name
         self._forward_models[name] = forward_model
 
-    def evaluate_model_response(self, theta, experiment_names=None):
-        """
-        Evaluates the model response for each forward model for the given
-        parameter vector theta and the given experiments.
-
-        Parameters
-        ----------
-        theta : array_like
-            A numeric vector for which the model responses should be evaluated.
-            Which parameters these numbers refer to can be checked by calling
-            self.theta_explanation() once the problem is set up.
-        experiment_names : str, list[str] or None, optional
-            Contains the names of all or some of the experiments added to the
-            inference  problem. If this argument is None (which is a common use
-            case) then all experiments defined in the problem (self.experiments)
-            are used. The names provided here define the experiments that the
-            forward model is evaluated for.
-
-        Returns
-        -------
-        model_response_dict : dict
-            The first key is the name of the experiment. The values are dicts
-            which contain the forward model's output sensor's names as keys
-            have the corresponding model responses as values.
-        """
-
-        # if experiments is not further specified all experiments added to the
-        # problem will be accounted for when computing the model error
-        if experiment_names is None:
-            experiment_names = [*self._experiments.keys()]
-        else:
-            # make sure that a given string is converted into a list
-            experiment_names = make_list(experiment_names)
-
-        # first, loop over all forward models, and then, over all experiments
-        # that are associated with the corresponding model
-        model_response_dict = {}
-        for fwd_name, forward_model in self._forward_models.items():
-            # get the model parameters for the considered forward model
-            prms_model = self.get_parameters(theta, forward_model.prms_def)
-            # get all experiments referring to the considered forward model
-            relevant_experiment_names = self.get_experiment_names(
-                forward_model_names=fwd_name, experiment_names=experiment_names)
-            # evaluate the forward model for each relevant experiment
-            for exp_name in relevant_experiment_names:
-                exp_dict = self._experiments[exp_name]
-                # prepare the model input values from the experimental data
-                sensor_values = exp_dict['sensor_values']
-                exp_inp = {input_sensor.name: sensor_values[input_sensor.name]
-                           for input_sensor in forward_model.input_sensors}
-                inp = {**exp_inp, **prms_model}  # adds the two dictionaries
-                # finally, evaluate the forward model for this experiment
-                model_response_dict[exp_name] = forward_model(inp)
-
-        return model_response_dict
-
     def add_noise_model(self, noise_model):
         """
         Adds a noise model to the inference problem.

--- a/probeye/subroutines.py
+++ b/probeye/subroutines.py
@@ -543,7 +543,7 @@ def translate_prms_def(prms_def_given):
     prms_dim = len(prms_def)
     return prms_def, prms_dim
 
-def print_probeye_header(width=100, header_file="probeye.txt", version='1.0.9',
+def print_probeye_header(width=100, header_file="probeye.txt", version='1.0.10',
                          margin=5, h_symbol="=", v_symbol="#", use_logger=True):
     """
     Prints the probeye header which is printed, when an inference problem is

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = probeye
-version = 1.0.9
+version = 1.0.10
 author = Alexander Klawonn
 author_email = alexander.klawonn@bam.de
 description = A general framework for setting up parameter estimation problems.

--- a/tests/integration_tests/test_maximum_likelihood.py
+++ b/tests/integration_tests/test_maximum_likelihood.py
@@ -1,0 +1,144 @@
+"""
+Linear regression example solved with max. likelihood (without needing priors).
+--------------------------------------------------------------------------------
+The model equation is y = m * x + b with a, b being the model parameters and the
+noise model is a normal zero-mean distribution with the std. deviation to infer.
+The problem is solved via maximum likelihood estimation based on scipy.
+"""
+
+# standard library imports
+import unittest
+
+# third party imports
+import numpy as np
+import matplotlib.pyplot as plt
+
+# local imports (problem definition)
+from probeye.definition.inference_problem import InferenceProblem
+from probeye.definition.forward_model import ForwardModelBase
+from probeye.definition.sensor import Sensor
+from probeye.definition.noise_model import NormalNoiseModel
+
+# local imports (inference related)
+from probeye.inference.scipy_.solver import ScipySolver
+
+
+class TestProblem(unittest.TestCase):
+
+    def test_maximum_likelihood(self, plot=False):
+        """
+        Integration test for the problem described at the top of this file.
+
+        Parameters
+        ----------
+        plot : bool, optional
+            If True, the problem's data is plotted. This is deactivated by
+            default, so that the test does not stop until the generated plots
+            are closed.
+        """
+
+        # ==================================================================== #
+        #                          Set numeric values                          #
+        # ==================================================================== #
+
+        # 'true' value of m
+        m_true = 2.5
+
+        # 'true' value of b
+        b_true = 1.7
+
+        # 'true' value of noise sd
+        sigma_noise = 0.5
+
+        # the number of generated experiment_names and seed for random numbers
+        n_tests = 50
+        seed = 1
+
+        # ==================================================================== #
+        #                       Define the Forward Model                       #
+        # ==================================================================== #
+
+        class LinearModel(ForwardModelBase):
+
+            def response(self, inp):
+                # this method *must* be provided by the user
+                x = inp['x']
+                m = inp['m']
+                b = inp['b']
+                response = {}
+                for os in self.output_sensors:
+                    response[os.name] = m * x + b
+                return response
+
+        # ==================================================================== #
+        #                     Define the Inference Problem                     #
+        # ==================================================================== #
+
+        # initialize the inference problem with a useful name; note that the
+        # name will only be stored as an attribute of the InferenceProblem and
+        # is not important for the problem itself; can be useful when dealing
+        # with multiple problems
+        problem = InferenceProblem("Max likelihood for linear regression")
+
+        # add all parameters to the problem; the first argument states the
+        # parameter's global name (here: 'm', 'b' and 'sigma'); the second
+        # argument defines the parameter type (three options: 'model' for
+        # parameter's of the forward model, 'prior' for prior parameters and
+        # 'noise' for parameters of the noise model); the tex argument is states
+        # a tex-string for the parameter which is only used for plotting
+        problem.add_parameter('m', 'model', tex="$m$")
+        problem.add_parameter('b', 'model', tex="$b$")
+        problem.add_parameter('sigma', 'noise', tex=r"$\sigma$")
+
+        # add the forward model to the problem
+        isensor = Sensor("x")
+        osensor = Sensor("y")
+        linear_model = LinearModel(['m', 'b'], [isensor], [osensor])
+        problem.add_forward_model("LinearModel", linear_model)
+
+        # add the noise model to the problem
+        problem.add_noise_model(NormalNoiseModel(
+            prms_def={'sigma': 'std'}, sensors=osensor))
+
+        # ==================================================================== #
+        #                Add test data to the Inference Problem                #
+        # ==================================================================== #
+
+        # data-generation; normal noise with constant variance around each point
+        np.random.seed(seed)
+        x_test = np.linspace(0.0, 1.0, n_tests)
+        y_true = linear_model.response(
+            {isensor.name: x_test, 'm': m_true, 'b': b_true})[osensor.name]
+        y_test = np.random.normal(loc=y_true, scale=sigma_noise)
+
+        # add the experimental data
+        problem.add_experiment(f'TestSeries_1', fwd_model_name="LinearModel",
+                               sensor_values={isensor.name: x_test,
+                                              osensor.name: y_test})
+
+        # give problem overview
+        problem.info()
+
+        # plot the true and noisy data
+        if plot:
+            plt.scatter(x_test, y_test, label='measured data',
+                        s=10, c="red", zorder=10)
+            plt.plot(x_test, y_true, label='true', c="black")
+            plt.xlabel(isensor.name)
+            plt.ylabel(osensor.name)
+            plt.legend()
+            plt.tight_layout()
+            plt.draw()  # does not stop execution
+
+        # ==================================================================== #
+        #                Solve problem with inference engine(s)                #
+        # ==================================================================== #
+
+        # this routine is imported from another script because it it used by all
+        # integration tests in the same way; ref_values are used for plotting
+        true_values = {'m': m_true, 'b': b_true, 'sigma': sigma_noise}
+        scipy_solver = ScipySolver(problem)
+        scipy_solver.run_max_likelihood(true_values=true_values)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/definition/test_inference_problem.py
+++ b/tests/unit_tests/definition/test_inference_problem.py
@@ -509,55 +509,6 @@ class TestProblem(unittest.TestCase):
             test_model_2 = ForwardModelBase('a', Sensor('x'), Sensor('y'))
             p.add_forward_model('TestModel_2', test_model_2)
 
-    def test_evaluate_model_response(self):
-        # prepare for checks
-        p = InferenceProblem("TestProblem")
-        p.add_parameter('a0', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
-        p.add_parameter('a1', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
-        p.add_parameter('a2', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
-
-        class FwdModel(ForwardModelBase):
-            def __call__(self, inp):
-                x = inp['x']
-                a0 = inp['a0']
-                a1 = inp['a1']
-                a2 = inp['a2']
-                return {'y': a0 + a1 * x + a2 * x ** 2}
-
-        # add forward model
-        fwd_model = FwdModel(['a0', 'a1', 'a2'], Sensor('x'), Sensor('y'))
-        p.add_forward_model('FwdModel', fwd_model)
-        # add experiment_names
-        p.add_experiment('Exp1', sensor_values={'x': 1, 'y': 2},
-                         fwd_model_name='FwdModel')
-        p.add_experiment('Exp2', sensor_values={'x': 2, 'y': 3},
-                         fwd_model_name='FwdModel')
-        p.add_experiment('Exp3', sensor_values={'x': [1, 2], 'y': [1, 2]},
-                         fwd_model_name='FwdModel')
-        # perform a check for all experiments
-        a0_value, a1_value, a2_value = 1, 2, 3
-        theta = np.array([a0_value, a1_value, a2_value])
-        computed_result = p.evaluate_model_response(theta)
-        expected_result = {'Exp1': {'y': 6},
-                           'Exp2': {'y': 17},
-                           'Exp3': {'y': np.array([6, 17])}}
-        # check for each item, because the last contains an array, which results
-        # in an error is you do assertEqual on the whole thing
-        self.assertEqual(computed_result['Exp1'], expected_result['Exp1'])
-        self.assertEqual(computed_result['Exp2'], expected_result['Exp2'])
-        self.assertEqual(computed_result['Exp3']['y'][0],
-                         expected_result['Exp3']['y'][0])
-        self.assertEqual(computed_result['Exp3']['y'][1],
-                         expected_result['Exp3']['y'][1])
-        # perform a check for a subset of experiments
-        computed_result = p.evaluate_model_response(
-            theta, experiment_names='Exp3')
-        expected_result = {'Exp3': {'y': np.array([6, 17])}}
-        self.assertEqual(computed_result['Exp3']['y'][0],
-                         expected_result['Exp3']['y'][0])
-        self.assertEqual(computed_result['Exp3']['y'][1],
-                         expected_result['Exp3']['y'][1])
-
     def test_add_noise_model(self):
         # check correct use
         p = InferenceProblem("TestProblem")

--- a/tests/unit_tests/inference/scipy_/test_solver.py
+++ b/tests/unit_tests/inference/scipy_/test_solver.py
@@ -71,5 +71,64 @@ class TestProblem(unittest.TestCase):
         problem.no_deepcopy_possible = (i for i in (1, 2, 3))
         ScipySolver(problem)  # this should result in a warning
 
+    def test_evaluate_model_response(self):
+        # prepare for checks
+        p = InferenceProblem("TestProblem")
+        p.add_parameter('a0', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('a1', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('a2', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('sigma', 'noise', const=1.0)
+
+        class FwdModel(ForwardModelBase):
+            def response(self, inp):
+                x = inp['x']
+                a0 = inp['a0']
+                a1 = inp['a1']
+                a2 = inp['a2']
+                return {'y': a0 + a1 * x + a2 * x ** 2}
+
+        # add forward and noise model
+        fwd_model = FwdModel(['a0', 'a1', 'a2'], Sensor('x'), Sensor('y'))
+        p.add_forward_model('FwdModel', fwd_model)
+        p.add_noise_model(NormalNoiseModel(
+            prms_def={'sigma': 'std'}, sensors=Sensor('y')))
+
+        # add experiment_names
+        p.add_experiment('Exp1', sensor_values={'x': 1, 'y': 2},
+                         fwd_model_name='FwdModel')
+        p.add_experiment('Exp2', sensor_values={'x': 2, 'y': 3},
+                         fwd_model_name='FwdModel')
+        p.add_experiment('Exp3', sensor_values={'x': [1, 2], 'y': [1, 2]},
+                         fwd_model_name='FwdModel')
+
+        # initialize the solver object
+        pyro_solver = ScipySolver(p)
+
+        # perform a check for all experiments
+        a0_value, a1_value, a2_value = 1, 2, 3
+        theta = np.array([a0_value, a1_value, a2_value])
+        computed_result = pyro_solver.evaluate_model_response(theta)
+        expected_result = {'Exp1': {'y': 6},
+                           'Exp2': {'y': 17},
+                           'Exp3': {'y': np.array([6, 17])}}
+
+        # check for each item, because the last contains an array, which results
+        # in an error is you do assertEqual on the whole thing
+        self.assertEqual(computed_result['Exp1'], expected_result['Exp1'])
+        self.assertEqual(computed_result['Exp2'], expected_result['Exp2'])
+        self.assertEqual(computed_result['Exp3']['y'][0],
+                         expected_result['Exp3']['y'][0])
+        self.assertEqual(computed_result['Exp3']['y'][1],
+                         expected_result['Exp3']['y'][1])
+
+        # perform a check for a subset of experiments
+        computed_result = pyro_solver.evaluate_model_response(
+            theta, experiment_names='Exp3')
+        expected_result = {'Exp3': {'y': np.array([6, 17])}}
+        self.assertEqual(computed_result['Exp3']['y'][0],
+                         expected_result['Exp3']['y'][0])
+        self.assertEqual(computed_result['Exp3']['y'][1],
+                         expected_result['Exp3']['y'][1])
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/inference/torch_/test_solver.py
+++ b/tests/unit_tests/inference/torch_/test_solver.py
@@ -109,5 +109,64 @@ class TestProblem(unittest.TestCase):
         problem.no_deepcopy_possible = (i for i in (1, 2, 3))
         PyroSolver(problem)  # this should result in a warning
 
+    def test_evaluate_model_response(self):
+        # prepare for checks
+        p = InferenceProblem("TestProblem")
+        p.add_parameter('a0', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('a1', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('a2', 'model', prior=('normal', {'loc': 0, 'scale': 1}))
+        p.add_parameter('sigma', 'noise', const=1.0)
+
+        class FwdModel(ForwardModelBase):
+            def response(self, inp):
+                x = inp['x']
+                a0 = inp['a0']
+                a1 = inp['a1']
+                a2 = inp['a2']
+                return {'y': a0 + a1 * x + a2 * x ** 2}
+
+        # add forward and noise model
+        fwd_model = FwdModel(['a0', 'a1', 'a2'], Sensor('x'), Sensor('y'))
+        p.add_forward_model('FwdModel', fwd_model)
+        p.add_noise_model(NormalNoiseModel(
+            prms_def={'sigma': 'std'}, sensors=Sensor('y')))
+
+        # add experiment_names
+        p.add_experiment('Exp1', sensor_values={'x': 1, 'y': 2},
+                         fwd_model_name='FwdModel')
+        p.add_experiment('Exp2', sensor_values={'x': 2, 'y': 3},
+                         fwd_model_name='FwdModel')
+        p.add_experiment('Exp3', sensor_values={'x': [1, 2], 'y': [1, 2]},
+                         fwd_model_name='FwdModel')
+
+        # initialize the solver object
+        pyro_solver = PyroSolver(p)
+
+        # perform a check for all experiments
+        a0_value, a1_value, a2_value = 1, 2, 3
+        theta = np.array([a0_value, a1_value, a2_value])
+        computed_result = pyro_solver.evaluate_model_response(theta)
+        expected_result = {'Exp1': {'y': 6},
+                           'Exp2': {'y': 17},
+                           'Exp3': {'y': np.array([6, 17])}}
+
+        # check for each item, because the last contains an array, which results
+        # in an error is you do assertEqual on the whole thing
+        self.assertEqual(computed_result['Exp1'], expected_result['Exp1'])
+        self.assertEqual(computed_result['Exp2'], expected_result['Exp2'])
+        self.assertEqual(computed_result['Exp3']['y'][0],
+                         expected_result['Exp3']['y'][0])
+        self.assertEqual(computed_result['Exp3']['y'][1],
+                         expected_result['Exp3']['y'][1])
+
+        # perform a check for a subset of experiments
+        computed_result = pyro_solver.evaluate_model_response(
+            theta, experiment_names='Exp3')
+        expected_result = {'Exp3': {'y': np.array([6, 17])}}
+        self.assertEqual(computed_result['Exp3']['y'][0],
+                         expected_result['Exp3']['y'][0])
+        self.assertEqual(computed_result['Exp3']['y'][1],
+                         expected_result['Exp3']['y'][1])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The evaluate_model_response method was moved from the InferenceProblem to the solver classes. This prevents the forward model being copied (which might be a problem) at the beginning of the solver initializations.