### PR TITLE
Improve dependency management

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,8 @@ name: CI
 
 on:
   push:
+  schedule:
+    - cron: '0 1 * * 6'  # weekly run at 01:00 UTC on Saturday, dependency check
 
 jobs:
   # Lint and type checking
@@ -82,6 +84,37 @@ jobs:
           label: coverage
           message: ${{ env.COVERAGE_PCT }}
           color: ${{ env.COVERAGE_COL }}
+
+  # Run tests with the latest available version of all dependencies
+  # these latest versions might be beyond the versions specified in `setup.cfg`
+  # the goal of this job to catch errors with these latest versions
+  # [only for `main`]. Ideally, if this job succeeded with at least one major
+  # version number increased then the `setup.cfg` would be updated.
+  test_with_latest:
+      name: Test with latest dependencies on Python ${{ matrix.python-version }}
+      runs-on: ubuntu-latest
+      if: |
+        github.ref == 'refs/heads/main' &&
+        github.repository == 'BAMresearch/probeye' &&
+        github.event_name == 'schedule'
+      needs: [ lint_and_type_check ]
+      strategy:
+        matrix:
+          python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+
+      steps:
+        - uses: actions/checkout@v2
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install package with latest dependencies
+          run: |
+            python probeye/_setup_cfg.py
+            pip install .[tests]
+        - name: Test with pytest
+          run: |
+            pytest
 
   # Release to GitHub and PyPi [only for `main`]
   #release:

--- a/probeye/_setup_cfg.py
+++ b/probeye/_setup_cfg.py
@@ -1,0 +1,74 @@
+"""This module contains functions that remove version number constraints from
+selected packages in the setup.cfg file. It is meant to be used during CI: to test if
+the package works with the latest versions of its dependencies."""
+
+import configparser
+import re
+from typing import List
+
+
+def version_constraint_free_packages(setup_cfg_packages: str) -> List[str]:
+    """
+    Remove version constraints from the packages listed in `options_field` (provided
+    as input argument or read from `setup.cfg`).
+
+    Parameters
+    ----------
+    setup_cfg_packages: str
+        Packages with optional version constraints as parsed from a syntactically
+        correct `setup.cfg` file.
+
+    Returns
+    -------
+    List[str]
+        `install_requires` packages without version constraints.
+    """
+    # to be able to match the last package in all cases
+    setup_cfg_packages = "\n" + setup_cfg_packages + "\n"
+
+    # get plain (version constraint free) package names, they are listed using a
+    # "list-semi": dangling list or string of semicolon-separated values
+    # https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#options
+    packages_without_version = re.findall(
+        r"(?<=(?:\n|;)).*?(?=<|=|>|!|;|\n|;])", setup_cfg_packages
+    )
+    # strip possible remaining spaces and drop empty string elements
+    packages_without_version = [s.strip() for s in packages_without_version]
+    packages_without_version = list(filter(None, packages_without_version))
+
+    return packages_without_version
+
+
+def version_constraint_free_dependencies(options_field: str) -> None:
+    """
+    Remove version constraints from the packages listed in `options_field` (
+    provided as input argument or read from `setup.cfg`) and overwrite the
+    `setup.cfg` file with the version constraint-free dependencies. Useful in a CI
+    pipeline to test if the package works with the latest versions of its dependencies.
+
+    Parameters
+    ----------
+    options_field: str
+        Field name in `setup.cfg` options that list package dependencies,
+        e.g. `"install_requires"`. For further information see:
+        https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#options
+
+    """
+    config = configparser.ConfigParser()
+    config.read("setup.cfg")
+    packages = config["options"][options_field]
+
+    packages_without_version = version_constraint_free_packages(packages)
+    setup_cfg_packages_without_version = "\n" + "\n".join(packages_without_version)
+
+    config["options"][options_field] = setup_cfg_packages_without_version
+
+    with open("setup.cfg", "w") as configfile:
+        config.write(configfile)
+
+
+# to ease running the version number constraint removal from the command line
+if __name__ == "__main__":
+    # this is meant to be run only during CI: to test if the package works with the
+    # latest versions of its dependencies
+    version_constraint_free_dependencies(options_field="install_requires")

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,15 +21,15 @@ license_files = LICENSE
 python_requires = >= 3.6
 packages = find:
 install_requires =
-    numpy
-    scipy
-    matplotlib
-    emcee
-    tabulate
-    torch
-    pyro-ppl
-    arviz
-    loguru
+    numpy<2
+    scipy<2
+    matplotlib<3
+    emcee<4
+    tabulate<1
+    torch<2
+    pyro-ppl<2
+    arviz<1
+    loguru<1
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ packages = find:
 install_requires =
     numpy<2
     scipy<2
-    matplotlib<3
+    matplotlib<4
     emcee<4
     tabulate<1
     torch<2

--- a/tests/unit_tests/test_setup_cfg.py
+++ b/tests/unit_tests/test_setup_cfg.py
@@ -1,0 +1,57 @@
+from probeye._setup_cfg import version_constraint_free_packages
+
+
+def test_version_removal():
+    p_in_list = [
+        "numpy<2",
+        "scipy!=1.10, >1.0",
+        "pandas",
+        "torch[dev]",
+        "matplotlib[dev]<=2",
+        "tensorflow==1.23rc",
+    ]
+    expected_p_out_list = [
+        "numpy",
+        "scipy",
+        "pandas",
+        "torch[dev]",
+        "matplotlib[dev]",
+        "tensorflow",
+    ]
+    for ii in range(len(p_in_list)):
+        p_in_list_ii = p_in_list[: (ii + 1)]
+        expected_p_out_list_ii = expected_p_out_list[: (ii + 1)]
+
+        # .......................................................
+        # Pure dangling list
+        # .......................................................
+        p_in = "\n" + "\n".join(p_in_list_ii)
+        p_out_list_ii = version_constraint_free_packages(setup_cfg_packages=p_in)
+        assert p_out_list_ii == expected_p_out_list_ii
+
+        # with extra space
+        p_in = "\n" + "\n ".join(p_in_list_ii)
+        p_out_list_ii = version_constraint_free_packages(setup_cfg_packages=p_in)
+        assert p_out_list_ii == expected_p_out_list_ii
+
+        # .......................................................
+        # Pure semi-colon separated list
+        # .......................................................
+        p_in = ";".join(p_in_list_ii)
+        p_out_list_ii = version_constraint_free_packages(setup_cfg_packages=p_in)
+        assert p_out_list_ii == expected_p_out_list_ii
+
+        # .......................................................
+        # Dangling list combined with semi-colon separated list
+        # .......................................................
+        if ii > 2:
+            p_in = (
+                "\n" + "\n".join(p_in_list_ii[:2]) + "\n" + ";".join(p_in_list_ii[2:])
+            )
+            p_out_list_ii = version_constraint_free_packages(setup_cfg_packages=p_in)
+            assert p_out_list_ii == expected_p_out_list_ii
+
+            # reversed order
+            p_in = "\n".join(p_in_list_ii[:2]) + "\n" + ";".join(p_in_list_ii[2:])
+            p_out_list_ii = version_constraint_free_packages(setup_cfg_packages=p_in)
+            assert p_out_list_ii == expected_p_out_list_ii


### PR DESCRIPTION
## Why

The current dependency specification (`install_requires` in `setup.cfg`) allows to install the latest version of each package that `probeye` is dependent on. This means that if one of the packages increases its main version number that version will be installed. However, if we assume that the package developers follow semantic versioning that means that at least one breaking change was introduced with the major version number increase, which in turn may break `probeye`.

## What

* Major version number upper limits are added to the `install_requires` dependencies.
* It is safer (causes fewer errors in CI pipelines and on the users' side) to disallow major version number increase of dependencies compared to their tried/tested highest version number.
* Based on my experience with python packages it is ok to assume that package developers follow semantic versioning (although there are many exceptions).
* If a dependency increases its major version number that can be tried/tested locally and/or on a separate branch and then the after taking the necessary actions (often no action is required) the major version number limit can be increased manually in the `setup.cfg` file.

## Testing

* GitHub actions
* local install

## Other

* I used semantic commit messages, following the guidelines outlined here: https://www.conventionalcommits.org/en/v1.0.0/. @aklawonn if you prefer to follow another convention please let me know.
* I recommend to squash the commits in the pull request (I think it is not yet allowed in the repo).