### PR TITLE
missing probeye.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # probeye changelog
 
-## 1.0.12 (2021-Nov-11)
+## 1.0.13 (2021-Nov-29)
+### Changed
+- fixed a bug with the probeye.txt file, which was missing in the build
+
+## 1.0.12 (2021-Nov-28)
 ### Changed
 - modified code format according to standard black and introduced type hints
 

--- a/probeye/subroutines.py
+++ b/probeye/subroutines.py
@@ -574,7 +574,7 @@ def translate_prms_def(prms_def_given: Union[str, list, dict]) -> Tuple[dict, in
 def print_probeye_header(
     width: int = 100,
     header_file: str = "probeye.txt",
-    version: str = "1.0.12",
+    version: str = "1.0.13",
     margin: int = 5,
     h_symbol: str = "=",
     v_symbol: str = "#",

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ license_files = LICENSE
 [options]
 python_requires = >= 3.6
 packages = find:
+include_package_data = True
 install_requires =
     numpy<2
     scipy<2
@@ -30,6 +31,9 @@ install_requires =
     pyro-ppl<2
     arviz<1
     loguru<1
+
+[options.package_data]
+probeye = probeye.txt
 
 [options.extras_require]
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = probeye
-version = 1.0.12
+version = 1.0.13
 author = Alexander Klawonn
 author_email = alexander.klawonn@bam.de
 description = A general framework for setting up parameter estimation problems.


### PR DESCRIPTION
The probeye.txt is missing in the build. It is now explicitly mentioned in the setup.cfg file.