### PR TITLE
Dynesty solver

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -48,8 +48,8 @@ jobs:
       - name: Test with pytest
         run: |
           # grab the coverage output and also print it to the sreen
-          COVERAGE_REPORT=$(coverage run -m pytest && coverage report -m | \
-            tee /dev/stderr)
+          coverage run -m pytest 
+          COVERAGE_REPORT=$(coverage report -m | tee /dev/stderr)
           # extract the percentage of the total coverage, e.g. `75%`
           COVERAGE_PCT=$(echo $COVERAGE_REPORT | \
             grep -oP "TOTAL\s+\d+\s+\d+\s+(\d+%)" | grep -oP "\d+%")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # probeye changelog
 
+## 1.0.15 (2021-Dec-01)
+### Added
+- added dynesty-solver (probeye/inference/dynesty_ submodule)
+
 ## 1.0.14 (2021-Nov-29)
 ### Changed
 - revised arviz-based post-processing routines

--- a/probeye/inference/__init__.py
+++ b/probeye/inference/__init__.py
@@ -1,4 +1,5 @@
 # subpackage imports
 from probeye.inference import scipy_
 from probeye.inference import emcee_
+from probeye.inference import dynesty_
 from probeye.inference import torch_

--- a/probeye/inference/dynesty_/__init__.py
+++ b/probeye/inference/dynesty_/__init__.py
@@ -1,0 +1,2 @@
+# module imports
+from probeye.inference.dynesty_ import solver

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -201,6 +201,8 @@ class DynestySolver(ScipySolver):
         logger.info(f"Total run-time: {runtime_str}.")
         logger.info("")
 
+        logger.info("Resample weighted samples to equal samples for post")
+        logger.info("processing. Access the original dynesty results via  .raw_results")
         weights = np.exp(sampler.results.logwt - sampler.results.logz[-1])
         samples = dynesty.utils.resample_equal(sampler.results.samples, weights)
 

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -74,8 +74,9 @@ class DynestySolver(ScipySolver):
                 i, j = np.nonzero(scale)
                 assert np.all(i == j)
 
-                for i in range(len(loc)):
-                    ppf.append(norm.ppf(q=x[i], loc=loc[i], scale=scale[i, i]))
+                mvn_ppf = norm.ppf(q=x, loc=loc, scale=np.diagonal(scale))
+                ppf += list(mvn_ppf)
+
         return ppf
 
     def get_summary(self, posterior_samples: np.ndarray) -> dict:

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -1,0 +1,211 @@
+# standard library imports
+from typing import TYPE_CHECKING
+import time
+import random
+import contextlib
+
+# third party imports
+import numpy as np
+import emcee
+import arviz as az
+from loguru import logger
+from tabulate import tabulate
+
+# local imports
+from probeye.subroutines import pretty_time_delta
+from probeye.subroutines import check_for_uninformative_priors
+from probeye.inference.scipy_.solver import ScipySolver
+from probeye.subroutines import stream_to_logger, print_dict_in_rows
+
+# imports only needed for type hints
+if TYPE_CHECKING:  # pragma: no cover
+    from probeye.definition.inference_problem import InferenceProblem
+
+
+class DynestySolver(ScipySolver):
+    """
+    Provides emcee-sampler which is a pure-Python implementation of Goodman & Weare’s
+    Affine Invariant Markov chain Monte Carlo (MCMC) Ensemble sampler. For more
+    information, check out https://emcee.readthedocs.io/en/stable/.
+    """
+
+    def __init__(
+        self, problem: "InferenceProblem", seed: int = 1, show_progress: bool = True
+    ):
+        """See docstring of ScipySolver for information on the arguments."""
+        logger.debug("Initializing EmceeSolver")
+        # check that the problem does not contain a uninformative prior
+        check_for_uninformative_priors(problem)
+        # initialize the scipy-based solver (ScipySolver)
+        super().__init__(problem, seed=seed, show_progress=show_progress)
+
+    def emcee_summary(self, posterior_samples: np.ndarray) -> dict:
+        """
+        Computes and prints a summary of the posterior samples containing mean, median,
+        standard deviation, 5th percentile and 95th percentile. Note, that this method
+        was based on code from the taralli package: https://gitlab.com/tno-bim/taralli.
+
+        Parameters
+        ----------
+        posterior_samples
+            The generated samples in an array with as many columns as there are latent
+            parameters, and n rows, where n = n_chains * n_steps.
+
+        Returns
+        -------
+            Keys are the different statistics 'mean', 'median', 'sd' (standard
+            deviation), 'q05' and 'q95' (0.05- and 0.95-quantile). The values are
+            dictionaries with the parameter names as keys and the respective statistics
+            as values.
+        """
+
+        # used for the names in the first column
+        var_names = self.problem.get_theta_names(tex=False, components=True)
+
+        # compute some stats for each column (i.e., each parameter)
+        mean = np.mean(posterior_samples, axis=0)
+        quantiles = np.quantile(posterior_samples, [0.50, 0.05, 0.95], axis=0)
+        median = quantiles[0, :]
+        quantile_05 = quantiles[1, :]
+        quantile_95 = quantiles[2, :]
+
+        # compute the sample standard deviations for each parameter
+        cov_matrix = np.atleast_2d(np.cov(posterior_samples.T))
+        sd = np.sqrt(np.diag(cov_matrix))
+
+        # assemble the summary array
+        col_names = ["", "mean", "median", "sd", "5%", "95%"]
+        row_names = np.array(var_names)
+        tab = np.hstack(
+            (
+                row_names.reshape(-1, 1),
+                mean.reshape(-1, 1),
+                median.reshape(-1, 1),
+                sd.reshape(-1, 1),
+                quantile_05.reshape(-1, 1),
+                quantile_95.reshape(-1, 1),
+            )
+        )
+
+        # print the generated table, and return a summary dict for later use
+        print(tabulate(tab, headers=col_names, floatfmt=".2f"))
+        return {
+            "mean": {name: val for name, val in zip(row_names, mean)},
+            "median": {name: val for name, val in zip(row_names, median)},
+            "sd": {name: val for name, val in zip(row_names, sd)},
+            "q05": {name: val for name, val in zip(row_names, quantile_05)},
+            "q95": {name: val for name, val in zip(row_names, quantile_95)},
+        }
+
+    def run_mcmc(
+        self,
+        n_walkers: int = 20,
+        n_steps: int = 1000,
+        n_initial_steps: int = 100,
+        **kwargs,
+    ) -> az.data.inference_data.InferenceData:
+        """
+        Runs the emcee-sampler for the InferenceProblem the EmceeSolver was initialized
+        with and returns the results as an arviz InferenceData obj.
+
+        Parameters
+        ----------
+        n_walkers
+            Number of walkers used by the estimator.
+        n_steps
+            Number of steps to run.
+        n_initial_steps
+            Number of steps for initial (burn-in) sampling.
+        kwargs
+            Additional key-word arguments channeled to emcee.EnsembleSampler.
+
+        Returns
+        -------
+        inference_data
+            Contains the results of the sampling procedure.
+        """
+
+        # log which solver is used
+        logger.info(
+            f"Solving problem using emcee sampler with {n_initial_steps} + {n_steps} "
+            f"samples and {n_walkers} walkers"
+        )
+        if kwargs:
+            logger.info("Additional options:")
+            print_dict_in_rows(kwargs, printer=logger.info)
+        else:
+            logger.info("No additional options specified")
+
+        # draw initial samples from the parameter's priors
+        logger.debug("Drawing initial samples")
+        sampling_initial_positions = np.zeros(
+            (n_walkers, self.problem.n_latent_prms_dim)
+        )
+        theta_names = self.problem.get_theta_names(tex=False, components=False)
+        for parameter_name in theta_names:
+            idx = self.problem.parameters[parameter_name].index
+            idx_end = self.problem.parameters[parameter_name].index_end
+            samples = self.sample_from_prior(parameter_name, n_walkers)
+            if (idx_end - idx) == 1:
+                sampling_initial_positions[:, idx] = samples
+            else:
+                sampling_initial_positions[:, idx:idx_end] = samples
+
+        # The following code is based on taralli and merely adjusted to the variables
+        # in the probeye setup; see https://gitlab.com/tno-bim/taralli
+
+        # ............................................................................ #
+        #                                 Pre-process                                  #
+        # ............................................................................ #
+
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        rstate = np.random.mtrand.RandomState(self.seed)
+
+        logger.debug("Setting up EnsembleSampler")
+        sampler = emcee.EnsembleSampler(
+            nwalkers=n_walkers,
+            ndim=self.problem.n_latent_prms_dim,
+            log_prob_fn=lambda x: self.logprior(x) + self.loglike(x),
+            **kwargs,
+        )
+
+        sampler.random_state = rstate
+
+        # ............................................................................ #
+        #        Initial sampling, burn-in: used to avoid a poor starting point        #
+        # ............................................................................ #
+
+        logger.debug("Starting sampling (initial + main)")
+        start = time.time()
+        state = sampler.run_mcmc(
+            initial_state=sampling_initial_positions,
+            nsteps=n_initial_steps,
+            progress=self.show_progress,
+        )
+        sampler.reset()
+
+        # ............................................................................ #
+        #                          Sampling of the posterior                           #
+        # ............................................................................ #
+        sampler.run_mcmc(
+            initial_state=state, nsteps=n_steps, progress=self.show_progress
+        )
+        end = time.time()
+        runtime_str = pretty_time_delta(end - start)
+        logger.info(
+            f"Sampling of the posterior distribution completed: {n_steps} steps and "
+            f"{n_walkers} walkers."
+        )
+        logger.info(f"Total run-time (including initial sampling): {runtime_str}.")
+        logger.info("")
+        logger.info("Summary of sampling results")
+        posterior_samples = sampler.get_chain(flat=True)
+        with contextlib.redirect_stdout(stream_to_logger("INFO")):  # type: ignore
+            self.summary = self.emcee_summary(posterior_samples)
+        self.raw_results = sampler
+
+        # translate the results to a common data structure and return it
+        var_names = self.problem.get_theta_names(tex=True, components=True)
+        inference_data = az.from_emcee(sampler, var_names=var_names)
+        return inference_data

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -55,17 +55,18 @@ class DynestySolver(ScipySolver):
 
         Returns
         -------
-        ppf
-            The vector of ppfs for each prior distribution at theta.
+        qs
+            The vector of quantiles for each prior distribution at theta.
         """
-        ppf = []
+        qs = []
         for prior in self.priors.values():
             prms = self.problem.get_parameters(theta, prior.prms_def)
             try:
-                ppf.append(prior(prms, "ppf"))
+                qs.append(prior(prms, "ppf"))
             except AttributeError as e:
-                # Assume to be multivariate and let it raise
-                # exceptions, if not.
+                # This branch is active when there is no `ppf` method in
+                # the prior distribution. For the case of a multivariate
+                # normal distribution, we implement a workaround.
                 loc = prms[f"loc_{prior.ref_prm}"]
                 scale = prms[f"scale_{prior.ref_prm}"]
                 x = prms[prior.ref_prm]
@@ -74,10 +75,10 @@ class DynestySolver(ScipySolver):
                 i, j = np.nonzero(scale)
                 assert np.all(i == j)
 
-                mvn_ppf = norm.ppf(q=x, loc=loc, scale=np.diagonal(scale))
-                ppf += list(mvn_ppf)
+                mvn_qs = norm.ppf(q=x, loc=loc, scale=np.diagonal(scale))
+                qs += list(mvn_qs)
 
-        return ppf
+        return qs
 
     def get_summary(self, posterior_samples: np.ndarray) -> dict:
         """

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -42,7 +42,7 @@ class DynestySolver(ScipySolver):
         # initialize the scipy-based solver (ScipySolver)
         super().__init__(problem, seed=seed, show_progress=show_progress)
 
-    def prior_transform(self, theta: np.ndarray) -> np.ndarray:
+    def prior_transform(self, theta: np.ndarray) -> list:
         """
         Evaluates the ppf of the prior distributions at theta.
 

--- a/probeye/inference/dynesty_/solver.py
+++ b/probeye/inference/dynesty_/solver.py
@@ -200,15 +200,14 @@ class DynestySolver(ScipySolver):
         runtime_str = pretty_time_delta(end - start)
         logger.info(f"Total run-time: {runtime_str}.")
         logger.info("")
-        logger.info("Summary of sampling results")
-
-        self.raw_results = sampler.results
 
         weights = np.exp(sampler.results.logwt - sampler.results.logz[-1])
         samples = dynesty.utils.resample_equal(sampler.results.samples, weights)
 
+        logger.info("Summary of sampling results")
         with contextlib.redirect_stdout(stream_to_logger("INFO")):  # type: ignore
             self.summary = self.get_summary(samples)
+        logger.info(f"Posterior log evidence: {sampler.results.logz[-1]}")
 
         var_names = self.problem.get_theta_names(tex=True, components=True)
 
@@ -216,4 +215,7 @@ class DynestySolver(ScipySolver):
 
         inference_data = az.convert_to_inference_data(posterior_dict)
         # TODO maybe add information like "source = dynesty", timestamp, etc ...
+
+        self.raw_results = sampler.results
+
         return inference_data

--- a/probeye/subroutines.py
+++ b/probeye/subroutines.py
@@ -574,7 +574,7 @@ def translate_prms_def(prms_def_given: Union[str, list, dict]) -> Tuple[dict, in
 def print_probeye_header(
     width: int = 100,
     header_file: str = "probeye.txt",
-    version: str = "1.0.14",
+    version: str = "1.0.15",
     margin: int = 5,
     h_symbol: str = "=",
     v_symbol: str = "#",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,10 @@
 [metadata]
 name = probeye
-version = 1.0.14
-author = Alexander Klawonn
+version = 1.0.15
+author =
+    Alexander Klawonn
+    Thomas Titscher
+    Jörg F. Unger
 author_email = alexander.klawonn@bam.de
 description = A general framework for setting up parameter estimation problems.
 long_description = file: README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     pyro-ppl<2
     arviz<1
     loguru<1
+    dynesty<2
 
 [options.package_data]
 probeye = probeye.txt

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,11 @@
-from setuptools import setup
+#!/usr/bin/env python
 
-setup()
+import setuptools
+import site
+import sys
+
+# https://github.com/googlefonts/fontmake/commit/164b24fd57c062297bf68b21c8ae88bc676f090b
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
+if __name__ == "__main__":
+    setuptools.setup()

--- a/tests/integration_tests/subroutines.py
+++ b/tests/integration_tests/subroutines.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from probeye.inference.scipy_.solver import ScipySolver
 from probeye.inference.emcee_.solver import EmceeSolver
 from probeye.inference.torch_.solver import PyroSolver
+from probeye.inference.dynesty_.solver import DynestySolver
 
 # local imports (post-processing)
 from probeye.postprocessing.sampling import create_pair_plot
@@ -30,6 +31,7 @@ def run_inference_engines(
     run_scipy: bool = True,
     run_emcee: bool = True,
     run_torch: bool = True,
+    run_dynesty: bool = True,
 ):
     """
     Runs a requested selection of inference engines on a given problem. This function is
@@ -62,6 +64,9 @@ def run_inference_engines(
     run_torch
         If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
         pyro/torch_ solver will not be used.
+    run_dynesty
+        If True, the problem is solved with the dynesty solver. Otherwise, the
+        dynesty solver will not be used.
     """
 
     def create_plots(inference_data, problem, true_values):
@@ -135,4 +140,9 @@ def run_inference_engines(
             n_steps=n_steps,
             n_initial_steps=n_initial_steps,
         )
+        create_plots(inference_data, problem, true_values)
+
+    if run_dynesty:
+        dynesty_solver = DynestySolver(problem, show_progress=show_progress)
+        inference_data = dynesty_solver.run_dynesty("static", nlive=250)
         create_plots(inference_data, problem, true_values)

--- a/tests/integration_tests/test_linear_regression.py
+++ b/tests/integration_tests/test_linear_regression.py
@@ -3,7 +3,7 @@ Simple linear regression example with two model and one noise parameter
 ----------------------------------------------------------------------------------------
 The model equation is y = a * x + b with a, b being the model parameters and the noise
 model is a normal zero-mean distribution with the std. deviation to infer. The problem
-is solved via sampling using emcee and pyro.
+is solved via max likelihood estimation and via sampling using emcee, pyro and dynesty.
 """
 
 # standard library imports
@@ -34,6 +34,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -62,6 +63,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         # ============================================================================ #
@@ -228,6 +232,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/integration_tests/test_multiple_sensors.py
+++ b/tests/integration_tests/test_multiple_sensors.py
@@ -6,8 +6,8 @@ while x and t represent position and time respectively. From the three model par
 A and B are latent ones while c is a constant. Measurements are made at three different
 positions (x-values) each of which is associated with an own zero-mean, uncorrelated
 normal noise model with the std. deviations to infer. This results in five latent
-parameters (parameters to infer). The problem is solved via sampling by means of emcee
-and pyro.
+parameters (parameters to infer). The problem is solved via max likelihood estimation
+and via sampling using emcee, pyro and dynesty.
 """
 
 # standard library imports
@@ -37,6 +37,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -65,6 +66,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         # ============================================================================ #
@@ -241,6 +245,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/integration_tests/test_multivariate_prior.py
+++ b/tests/integration_tests/test_multivariate_prior.py
@@ -34,7 +34,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
-        run_dynesty: bool = False,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.

--- a/tests/integration_tests/test_multivariate_prior.py
+++ b/tests/integration_tests/test_multivariate_prior.py
@@ -3,7 +3,7 @@ Simple linear regression example with two model and one noise parameter
 ----------------------------------------------------------------------------------------
 The model equation is y = a * x + b with a, b being the model parameters and the noise
 model is a normal zero-mean distribution with the std. deviation to infer. The problem
-is solved via sampling using emcee and pyro.
+is solved via max likelihood estimation and via sampling using emcee, pyro and dynesty.
 """
 
 # standard library imports

--- a/tests/integration_tests/test_multivariate_prior.py
+++ b/tests/integration_tests/test_multivariate_prior.py
@@ -34,6 +34,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
+        run_dynesty: bool = False,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -62,6 +63,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         # ============================================================================ #
@@ -231,6 +235,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/integration_tests/test_prior_calibration.py
+++ b/tests/integration_tests/test_prior_calibration.py
@@ -3,8 +3,8 @@ Linear regression example where a prior parameter is a latent parameter
 ----------------------------------------------------------------------------------------
 The model equation is y = a * x + b with a, b being the model parameters and the noise
 model is a normal zero-mean distribution with the std. deviation to infer. Additionally,
-the location parameter of a's prior is considered a latent parameter.The problem is
-solved via sampling using emcee and pyro.
+the location parameter of a's prior is considered a latent parameter. The problem is
+solved via max likelihood estimation and via sampling using emcee, pyro and dynesty.
 """
 
 # standard library imports
@@ -36,6 +36,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -64,6 +65,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         # ============================================================================ #
@@ -204,6 +208,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/integration_tests/test_spatial_correlation.py
+++ b/tests/integration_tests/test_spatial_correlation.py
@@ -9,7 +9,7 @@ correlated. The corresponding covariance matrix is defined based on an exponenti
 correlation function parameterized by the const standard deviation sigma of the
 n-variate normal distribution and a correlation length l_corr. Hence, the full model has
 four parameters a, b, sigma, l_corr, all of which are inferred in this example using
-emcee-sampling.
+via maximum likelihood estimation and via sampling using emcee and dynesty.
 """
 
 # standard library
@@ -43,6 +43,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = False,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -71,6 +72,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         if run_torch:
@@ -248,6 +252,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/integration_tests/test_two_models.py
+++ b/tests/integration_tests/test_two_models.py
@@ -5,7 +5,8 @@ The first model equation is y = a * x + b with a, b being the model parameters a
 second model equation is y = alpha * x**2 + b where alpha is a new model parameter, and
 b is the same model parameter as in the first model equation. Both forward models have
 the same noise model with a normal zero-mean distribution where the standard deviation
-is to be inferred.The problem is solved via sampling using emcee and pyro.
+is to be inferred. The problem is solved via max likelihood estimation and via sampling
+using emcee, pyro and dynesty.
 """
 
 # standard library imports
@@ -36,6 +37,7 @@ class TestProblem(unittest.TestCase):
         run_scipy: bool = True,
         run_emcee: bool = True,
         run_torch: bool = True,
+        run_dynesty: bool = True,
     ):
         """
         Integration test for the problem described at the top of this file.
@@ -64,6 +66,9 @@ class TestProblem(unittest.TestCase):
         run_torch
             If True, the problem is solved with the pyro/torch_ solver. Otherwise, the
             pyro/torch_ solver will not be used.
+        run_dynesty
+            If True, the problem is solved with the dynesty solver. Otherwise, the
+            dynesty solver will not be used.
         """
 
         # ============================================================================ #
@@ -257,6 +262,7 @@ class TestProblem(unittest.TestCase):
             run_scipy=run_scipy,
             run_emcee=run_emcee,
             run_torch=run_torch,
+            run_dynesty=run_dynesty,
         )
 
 

--- a/tests/unit_tests/inference/dynesty_/test_solver.py
+++ b/tests/unit_tests/inference/dynesty_/test_solver.py
@@ -1,0 +1,63 @@
+# standard library
+import logging
+import unittest
+
+# third party imports
+import numpy as np
+
+# local imports
+from probeye.definition.forward_model import ForwardModelBase
+from probeye.definition.sensor import Sensor
+from probeye.definition.inference_problem import InferenceProblem
+from probeye.definition.noise_model import NormalNoiseModel
+from probeye.inference.dynesty_.solver import DynestySolver
+
+
+class TestProblem(unittest.TestCase):
+    def test_dynesty_solver(self):
+
+        np.random.seed(6174)
+
+        # define the forward model
+        class LinRe(ForwardModelBase):
+            def __call__(self, inp):
+                x = inp["x"]
+                a = inp["a"]
+                b = inp["b"]
+                return {"y": a * x + b}
+
+        # set up the problem
+        problem = InferenceProblem("Linear regression")
+        problem.add_parameter("a", "model", prior=("normal", {"loc": 0, "scale": 1}))
+        problem.add_parameter("b", "model", prior=("normal", {"loc": 0, "scale": 1}))
+        problem.add_parameter(
+            "sigma", "noise", prior=("uniform", {"low": 0.1, "high": 1})
+        )
+        problem.add_forward_model(
+            "LinRe", LinRe(["a", "b"], [Sensor("x")], [Sensor("y")])
+        )
+        problem.add_noise_model(NormalNoiseModel({"sigma": "std"}, sensors=Sensor("y")))
+
+        # generate and add some simple test data
+        n_tests, a_true, b_true, sigma_true = 5000, 0.3, -0.2, 0.1
+        x_test = np.linspace(0.0, 1.0, n_tests)
+        y_true = a_true * x_test + b_true
+        y_test = np.random.normal(loc=y_true, scale=sigma_true)
+        problem.add_experiment(
+            f"Tests", fwd_model_name="LinRe", sensor_values={"x": x_test, "y": y_test}
+        )
+
+        # run the emcee solver with deactivated output
+        logging.root.disabled = True
+        dynesty_solver = DynestySolver(problem, show_progress=False, seed=6174)
+        _ = dynesty_solver.run_mcmc(n_walkers=20, n_steps=200, vectorize=False)
+        # summary = run_emcee_postprocessing(problem, emcee_sampler,
+        #                                    show_progress=True)
+        # sample_means = summary['mean']
+        # for mean, mean_true\
+        #         in zip(sample_means, [a_true, b_true, sigma_true]):
+        #     self.assertAlmostEqual(mean, mean_true, delta=0.01)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit_tests/inference/dynesty_/test_solver.py
+++ b/tests/unit_tests/inference/dynesty_/test_solver.py
@@ -39,24 +39,23 @@ class TestProblem(unittest.TestCase):
         problem.add_noise_model(NormalNoiseModel({"sigma": "std"}, sensors=Sensor("y")))
 
         # generate and add some simple test data
-        n_tests, a_true, b_true, sigma_true = 5000, 0.3, -0.2, 0.1
+        n_tests = 5000
+        true = {"a": 0.3, "b": -0.2, "sigma": 0.1}
         x_test = np.linspace(0.0, 1.0, n_tests)
-        y_true = a_true * x_test + b_true
-        y_test = np.random.normal(loc=y_true, scale=sigma_true)
+        y_true = true["a"] * x_test + true["b"]
+        y_test = np.random.normal(loc=y_true, scale=true["sigma"])
         problem.add_experiment(
             f"Tests", fwd_model_name="LinRe", sensor_values={"x": x_test, "y": y_test}
         )
 
-        # run the emcee solver with deactivated output
+        # run the dynesty solver with deactivated output
         logging.root.disabled = True
         dynesty_solver = DynestySolver(problem, show_progress=False, seed=6174)
-        _ = dynesty_solver.run_mcmc(n_walkers=20, n_steps=200, vectorize=False)
-        # summary = run_emcee_postprocessing(problem, emcee_sampler,
-        #                                    show_progress=True)
-        # sample_means = summary['mean']
-        # for mean, mean_true\
-        #         in zip(sample_means, [a_true, b_true, sigma_true]):
-        #     self.assertAlmostEqual(mean, mean_true, delta=0.01)
+        dynesty_solver.run_dynesty("static", nlive=50)
+
+        sample_means = dynesty_solver.summary["mean"]
+        for parameter, true_value in true.items():
+            self.assertAlmostEqual(sample_means[parameter], true_value, delta=0.01)
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/inference/dynesty_/test_solver.py
+++ b/tests/unit_tests/inference/dynesty_/test_solver.py
@@ -50,8 +50,8 @@ class TestProblem(unittest.TestCase):
 
         # run the dynesty solver with deactivated output
         logging.root.disabled = True
-        dynesty_solver = DynestySolver(problem, show_progress=False, seed=6174)
-        dynesty_solver.run_dynesty("static", nlive=50)
+        dynesty_solver = DynestySolver(problem, show_progress=True, seed=6174)
+        dynesty_solver.run_dynesty("dynamic", nlive_init=10, nlive_batch=10, maxbatch=2)
 
         sample_means = dynesty_solver.summary["mean"]
         for parameter, true_value in true.items():

--- a/tests/unit_tests/inference/emcee_/test_solver.py
+++ b/tests/unit_tests/inference/emcee_/test_solver.py
@@ -39,10 +39,11 @@ class TestProblem(unittest.TestCase):
         problem.add_noise_model(NormalNoiseModel({"sigma": "std"}, sensors=Sensor("y")))
 
         # generate and add some simple test data
-        n_tests, a_true, b_true, sigma_true = 5000, 0.3, -0.2, 0.1
+        n_tests = 5000
+        true = {"a": 0.3, "b": -0.2, "sigma": 0.1}
         x_test = np.linspace(0.0, 1.0, n_tests)
-        y_true = a_true * x_test + b_true
-        y_test = np.random.normal(loc=y_true, scale=sigma_true)
+        y_true = true["a"] * x_test + true["b"]
+        y_test = np.random.normal(loc=y_true, scale=true["sigma"])
         problem.add_experiment(
             f"Tests", fwd_model_name="LinRe", sensor_values={"x": x_test, "y": y_test}
         )
@@ -50,13 +51,11 @@ class TestProblem(unittest.TestCase):
         # run the emcee solver with deactivated output
         logging.root.disabled = True
         emcee_solver = EmceeSolver(problem, show_progress=False, seed=6174)
-        _ = emcee_solver.run_mcmc(n_walkers=20, n_steps=200, vectorize=False)
-        # summary = run_emcee_postprocessing(problem, emcee_sampler,
-        #                                    show_progress=True)
-        # sample_means = summary['mean']
-        # for mean, mean_true\
-        #         in zip(sample_means, [a_true, b_true, sigma_true]):
-        #     self.assertAlmostEqual(mean, mean_true, delta=0.01)
+        emcee_solver.run_mcmc(n_walkers=20, n_steps=200, vectorize=False)
+
+        sample_means = emcee_solver.summary["mean"]
+        for parameter, true_value in true.items():
+            self.assertAlmostEqual(sample_means[parameter], true_value, delta=0.01)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement `dynesty` solver with "dynamic" and "static" nested sampling options. Remarks:
* ~~It would be nice to actually test the "dynamic" mode [here](https://github.com/BAMresearch/probeye/blob/dynesty_solver/tests/unit_tests/inference/dynesty_/test_solver.py#L54), but that takes minutes to complete, which I find too long for the test. @rozsasarpi are there dynesty options to speed that up?~~
* Nested samplers do not work with the logprior, but the prior quantile function. This is not always part of the `scipy` distributions, e.g. for the MVN. I specifically implemented the quantile function for the case of a uncorrelated MVN within the solver. Is that OK for now?
* The solver outputs `arviz.InferenceData` with only the posterior samples, which seems to be sufficient for our visualization. Is more information needed/preferred?