### PR TITLE
check parameter domain

### DIFF
--- a/probeye/definition/inference_problem.py
+++ b/probeye/definition/inference_problem.py
@@ -1303,3 +1303,24 @@ class InferenceProblem:
                     f"The globally defined experiment '{exp_name}' does not appear in "
                     f"any of the likelihood models!"
                 )
+    
+    def check_parameters_domain(self, theta):
+        """
+        Checks weather the given values of the latent parameters are within the
+        specified domain.
+
+        Parameters
+        ----------
+        theta
+            A numeric vector or tensor, which contains the current values of all latent parameters.
+
+        Returns
+        -------
+        True if all values are within the specified domain. Otherwise, False is returned.
+        """
+        for theta_idx, theta_name in enumerate(self.get_theta_names()):
+            if theta[theta_idx] < self._parameters[theta_name].domain[0][0]:
+                return False
+            elif theta[theta_idx] > self._parameters[theta_name].domain[0][1]:
+                return False
+        return True       

--- a/probeye/inference/scipy/solver.py
+++ b/probeye/inference/scipy/solver.py
@@ -195,6 +195,13 @@ class ScipySolver:
         ll
             The evaluated log-likelihood function for the given theta-vector.
         """
+        
+        # check whether the values of the latent parameters are within the specified domain.
+        # if they are outside of the domain, break calculating the log-likelihood function
+        # and return instead of it minus infinity.
+        if self.problem.check_parameters_domain(theta) == False:
+            return -np.inf
+        
         # compute the contribution to the log-likelihood function for each likelihood
         # model and sum it all up
         ll = 0.0

--- a/probeye/inference/torch/solver.py
+++ b/probeye/inference/torch/solver.py
@@ -395,6 +395,14 @@ class PyroSolver:
             A vector of pyro.samples (i.e. tensors) for which the log-likelihood
             function should be evaluated.
         """
+        
+        # check whether the values of the latent parameters are within the specified domain.
+        # if they are outside of the domain, break calculating the log-likelihood function
+        # and return instead of it minus infinity.
+        
+        if self.problem.check_parameters_domain(theta) == False:
+            return -np.inf
+        
         # compute the contribution to the log-likelihood function for each likelihood
         # model and sum it all up
         for likelihood_model in self.likelihood_models:


### PR DESCRIPTION
In this pull request a method is implemented that checks the parameters domain.
The loglike-methods now use this method to proof whether the latent parameters are within the specified domain. If they are not in the domain the loglike-methodes return  "-inf". 
The corresponding issue: #69 