### PR TITLE
surrogate model

### DIFF
--- a/probeye/definition/__init__.py
+++ b/probeye/definition/__init__.py
@@ -2,6 +2,7 @@
 from probeye.definition import inverse_problem
 from probeye.definition import inference_problem
 from probeye.definition import forward_model
+from probeye.definition import surrogate_model
 from probeye.definition import likelihood_model
 from probeye.definition import parameter
 from probeye.definition import prior

--- a/probeye/definition/inverse_problem.py
+++ b/probeye/definition/inverse_problem.py
@@ -10,6 +10,7 @@ import numpy as np
 # local imports
 from probeye.definition.parameter import Parameters
 from probeye.definition.forward_model import ForwardModelBase
+from probeye.definition.surrogate_model import SurrogateModelBase
 from probeye.definition.likelihood_model import GaussianLikelihoodModel
 from probeye.subroutines import underlined_string, titled_table
 from probeye.subroutines import simplified_list_string
@@ -95,6 +96,13 @@ class InverseProblem:
         # the script forward_model.py); this dictionary is managed internally and should
         # not be modified directly
         self._forward_models = {}  # type: dict
+
+        # the following dict contains the problem's surrogate models (note that
+        # surrogate models are optional, not every problem has surrogate models);
+        # the keys in this dict are the surrogate model names, while the values are the
+        # surrogate model objects (check out the script surrogate_model.py); this
+        # dictionary is managed internally and should not be modified directly
+        self._surrogate_models = {}  # type: dict
 
         # this dictionary contains the problem's likelihood models; as the other private
         # attributes above, it is managed internally and should not be modified directly
@@ -210,6 +218,11 @@ class InverseProblem:
     def forward_models(self) -> dict:
         """Access self._forward_models from outside via self.forward_models."""
         return self._forward_models
+
+    @property
+    def surrogate_models(self) -> dict:
+        """Access self._surrogate_models from outside via self.forward_models."""
+        return self._surrogate_models
 
     @property
     def experiments(self) -> dict:
@@ -639,6 +652,60 @@ class InverseProblem:
         # add the given forward model to the internal forward model dictionary under
         # the given forward model name
         self._forward_models[forward_model.name] = forward_model
+
+    def add_surrogate_model(self, surrogate_model: SurrogateModelBase):
+        """
+        Adds a surrogate model to the inverse problem. Note that multiple forward models
+        can be added to one problem.
+
+        Parameters
+        ----------
+        surrogate_model
+            Defines the surrogate model. Check out surrogate_model.py to see a template
+            for the surrogate model definition. The user will then have to derive her
+            own surrogate model from that base class. Examples can be found in the
+            package directory tests/integration_tests.
+        """
+
+        # log at beginning so that errors can be quickly associated
+        logger.debug(f"Adding surrogate model '{surrogate_model.name}'")
+
+        # check if all given model parameters have already been added to the inverse
+        # problem; note that the surrogate model can only be added to the problem after
+        # the corresponding parameters and the forward model have been defined
+        for prm_name in surrogate_model.prms_def:
+            self._parameters.confirm_that_parameter_exists(prm_name)
+            # check, if the type was set correctly; if it was not set yet, it will be
+            # set automatically here
+            if self._parameters[prm_name].type == "not defined":
+                self.change_parameter_type(prm_name, "model")
+            elif self._parameters[prm_name].type in ["prior", "likelihood"]:
+                raise ValueError(
+                    f"The parameter '{prm_name}' defined in forward model "
+                    f"'{surrogate_model.name}' was assigned the type "
+                    f"'{self._parameters[prm_name].type}' (it should be 'model')."
+                )
+
+        # check if the given name for the forward model has already been used
+        if surrogate_model.name in self._surrogate_models:
+            raise RuntimeError(
+                f"The name '{surrogate_model.name}' of the surrogate model you are "
+                f"trying to add to the problem has already been used for another"
+                f"surrogate model within the problem scope. Please choose another name."
+            )
+
+        # check if the surrogate model's forward model has already been added to the
+        # inverse problem
+        if surrogate_model.forward_model.name not in self._forward_models:
+            raise RuntimeError(
+                f"The surrogate model's forward model "
+                f"'{surrogate_model.forward_model.name}' has not been added to the "
+                f"problem yet!"
+            )
+
+        # add the given surrogate model to the internal surrogate model dictionary under
+        # the given surrogate model name
+        self._surrogate_models[surrogate_model.name] = surrogate_model
 
     # =============================================================== #
     #                   Experiments related methods                   #

--- a/probeye/definition/surrogate_model.py
+++ b/probeye/definition/surrogate_model.py
@@ -1,0 +1,32 @@
+# local imports
+from probeye.definition.forward_model import ForwardModelBase
+
+
+class SurrogateModelBase(ForwardModelBase):
+    """
+    Base class for a surrogate model, i.e., a forward model that approximates another
+    (typically computationally more expensive) forward model.
+
+    Parameters
+    ----------
+    name
+        The name of the surrogate model. Must be unique among all surrogate model's
+        names within a considered InverseProblem.
+    forward_model
+        The forward model object that the surrogate model approximates.
+    """
+
+    def __init__(self, name: str, forward_model: ForwardModelBase):
+
+        super().__init__(name)
+
+        # the surrogate model has access to the forward model it approximates; this
+        # forward model can be called (evaluating its response) from the surrogate model
+        # via self.forward_model.response(inp) where inp contains the input dictionary
+        self.forward_model = forward_model
+
+    def fit(self):
+        """
+        Prepares the surrogate model by approximating the forward model in some way.
+        """
+        pass

--- a/tests/integration_tests/tests_without_correlation/test_surrogate_model.py
+++ b/tests/integration_tests/tests_without_correlation/test_surrogate_model.py
@@ -1,0 +1,176 @@
+# standard library imports
+import unittest
+import time
+
+# third party imports
+import numpy as np
+import matplotlib.pyplot as plt
+
+# local imports (problem definition)
+from probeye.definition.inverse_problem import InverseProblem
+from probeye.definition.forward_model import ForwardModelBase
+from probeye.definition.surrogate_model import SurrogateModelBase
+from probeye.definition.sensor import Sensor
+from probeye.definition.likelihood_model import GaussianLikelihoodModel
+
+
+class TestProblem(unittest.TestCase):
+    def test_surrogate_model(self, plot: bool = False):
+        """
+        Demonstrates how to use a surrogate model. Still under discussion.
+
+        Parameters
+        ----------
+        plot
+            Triggers a plot of the data used for calibration.
+        """
+
+        # ============================================================================ #
+        #                              Set numeric values                              #
+        # ============================================================================ #
+
+        # 'true' value of a, and its normal prior parameters
+        m_true = 2.5
+        mean_m = 2.0
+        std_m = 1.0
+
+        # 'true' value of b, and its normal prior parameters
+        b_true = 1.7
+        mean_b = 1.0
+        std_b = 1.0
+
+        # 'true' value of additive error sd, and its uniform prior parameters
+        sigma = 0.5
+        low_sigma = 0.0
+        high_sigma = 0.8
+
+        # the number of generated experiment_names and seed for random numbers
+        n_tests = 50
+        seed = 1
+
+        # ============================================================================ #
+        #                           Define the Forward Model                           #
+        # ============================================================================ #
+
+        class ExpensiveModel(ForwardModelBase):
+            def interface(self):
+                self.parameters = ["m", "b"]
+                self.input_sensors = Sensor("x")
+                self.output_sensors = Sensor("y", std_model="sigma")
+
+            def response(self, inp: dict) -> dict:
+                x = inp["x"]
+                m = inp["m"]
+                b = inp["b"]
+                time.sleep(1.0)
+                return {"y": m * x + b}
+
+        # ============================================================================ #
+        #                          Define the Surrogate Model                          #
+        # ============================================================================ #
+
+        class SurrogateModel(ExpensiveModel, SurrogateModelBase):
+            """
+            The inheritance from ExpensiveModel 'copies' the interface-method from
+            ExpensiveModel (the surrogate model should have the same interface as the
+            forward model). The inheritance from SurrogateModelBase is required to
+            assign a forward model to the surrogate model, see surrogate_model.py.
+            """
+
+            def response(self, inp: dict) -> dict:
+                x = inp["x"]
+                m = inp["m"]
+                b = inp["b"]
+                return {"y": m * x + b}
+
+        # ============================================================================ #
+        #                         Define the Inference Problem                         #
+        # ============================================================================ #
+
+        # initialize the inverse problem with a useful name
+        problem = InverseProblem("Using a surrogate model")
+
+        # add all parameters to the problem
+        problem.add_parameter(
+            "m",
+            "model",
+            tex="$m$",
+            info="Slope of the graph",
+            prior=("normal", {"mean": mean_m, "std": std_m}),
+        )
+        problem.add_parameter(
+            "b",
+            "model",
+            info="Intersection of graph with y-axis",
+            tex="$b$",
+            prior=("normal", {"mean": mean_b, "std": std_b}),
+        )
+        problem.add_parameter(
+            "sigma",
+            "likelihood",
+            domain="(0, +oo)",
+            tex=r"$\sigma$",
+            info="Standard deviation, of zero-mean additive model error",
+            prior=("uniform", {"low": low_sigma, "high": high_sigma}),
+        )
+
+        # add the forward model to the problem
+        forward_model = ExpensiveModel("ExpensiveModel")
+        problem.add_forward_model(forward_model)
+
+        # add the forward model to the problem
+        surrogate_model = SurrogateModel("FastModel", forward_model=forward_model)
+        problem.add_surrogate_model(surrogate_model)
+
+        # ============================================================================ #
+        #                    Add test data to the Inference Problem                    #
+        # ============================================================================ #
+
+        # data-generation; normal likelihood with constant variance around each point
+        np.random.seed(seed)
+        x_test = np.linspace(0.0, 1.0, n_tests)
+        y_true = surrogate_model.response(
+            {surrogate_model.input_sensor.name: x_test, "m": m_true, "b": b_true}
+        )[surrogate_model.output_sensor.name]
+        y_test = np.random.normal(loc=y_true, scale=sigma)
+
+        # add the experimental data
+        problem.add_experiment(
+            f"TestSeries_1",
+            fwd_model_name="ExpensiveModel",
+            sensor_values={
+                forward_model.input_sensor.name: x_test,
+                forward_model.output_sensor.name: y_test,
+            },
+        )
+
+        # plot the true and noisy data
+        if plot:
+            plt.scatter(x_test, y_test, label="measured data", s=10, c="red", zorder=10)
+            plt.plot(x_test, y_true, label="true", c="black")
+            plt.xlabel(forward_model.input_sensor.name)
+            plt.ylabel(forward_model.output_sensor.name)
+            plt.legend()
+            plt.tight_layout()
+            plt.draw()  # does not stop execution
+
+        # ============================================================================ #
+        #                           Add likelihood model(s)                            #
+        # ============================================================================ #
+
+        # add the likelihood model to the problem
+        problem.add_likelihood_model(
+            GaussianLikelihoodModel(
+                prms_def="sigma",
+                experiment_name="TestSeries_1",
+                model_error="additive",
+                name="SimpleLikelihoodModel",
+            )
+        )
+
+        # give problem overview
+        problem.info()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the code structure for using surrogate models (meta models, response surfaces) with probeye. This structure is up for discussion, so please feel free to comment and propose changes. In order to check the currently intended use of a surrogate model, check out [this](https://github.com/BAMresearch/probeye/blob/surrogate_model/tests/integration_tests/tests_without_correlation/test_surrogate_model.py) integration test.