### PR TITLE
Fix emcee sampling out of bounds when bounds are not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # probeye changelog
 
+## 2.3.3 (2022-Jul-01)
+### Changed
+- The likelihood function in the emcee-solver has been equipped with a check if the log-prior was evaluated to minus infinity to prevent unnecessary likelihood evaluations.
+
 ## 2.3.2 (2022-May-30)
 ### Added
 - The Scipy-solver was equipped with a maximum a-posteriori estimation method.

--- a/probeye/__init__.py
+++ b/probeye/__init__.py
@@ -1,3 +1,3 @@
 # this is the only place to define the package version; it is currently used by
 # setup.cfg, docs/conf.py and by the method print_probeye_header in subroutines.py
-__version__ = "2.3.2"
+__version__ = "2.3.3"

--- a/probeye/inference/emcee/solver.py
+++ b/probeye/inference/emcee/solver.py
@@ -208,11 +208,21 @@ class EmceeSolver(ScipySolver):
         np.random.seed(self.seed)
         rstate = np.random.mtrand.RandomState(self.seed)
 
+        def logprob(x):
+            # Skip loglikelihood evaluation if logprior is equal
+            # to negative infinity
+            logprior = self.logprior(x)
+            if logprior == -np.inf:
+                return logprior
+
+            # Otherwise return logprior + loglikelihood
+            return logprior + self.loglike(x)
+
         logger.debug("Setting up EnsembleSampler")
         sampler = emcee.EnsembleSampler(
             nwalkers=n_walkers,
             ndim=self.problem.n_latent_prms_dim,
-            log_prob_fn=lambda x: self.logprior(x) + self.loglike(x),
+            log_prob_fn=logprob,
             **kwargs,
         )
 


### PR DESCRIPTION
This pull request modifies the emcee solver to avoid evaluating the log-likelihood for samples that are out of bounds, even when the bounds are not specified in the parameter definition. In such cases, the log-prior will be equal to `-inf`. Previously, the log-likelihood function would still be evaluated, unnecessarily increasing computational time and leading to errors in the likelihood function due to unexpected parameter values (e.g. negative standard deviation or correlation length). With the suggested change the value of the log-prior is checked, and if it is equal to `-inf` the log-likelihood evaluation is skipped and only the log-prior is returned, signaling to emcee that the sample is out of bounds.

This PR will be marked as draft, pending some additional checks to make sure the emcee solver still works as intended.