### PR TITLE
forward model arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # probeye changelog
 
+## 3.0.3 (2022-Aug-14)
+### Changed
+- The forward model's init method can now take positional and keyword arguments.
+- Small correction in docs (Mathematics sections, sigma_m -> sigma_m^2).
+
 ## 3.0.2 (2022-Jul-31)
 ### Changed
 - Ensured reproducibility of solver results via seeds. It is also possible now to not use a seed (instead of a default seed). The reproducibility of the sampling results is explicitly checked in the unit tests of the solvers.

--- a/docs/mathematics.rst
+++ b/docs/mathematics.rst
@@ -23,20 +23,20 @@ where :math:`\bm\theta_y\in\mathbb{R}^n`, :math:`n\in\mathbb{N}` is the model pa
 
     \mathbf{Y}_e = \mathbf{y}(\mathbf{x}_e,\bm\theta_y) + \mathbf{E}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) + \mathbf{E}_\mathrm{meas}
 
-Here, :math:`\mathbf{E}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) \sim \mathcal{N}(\mathbf{0}, \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell))` denotes a Gaussian model for the prediction error, introducing additional latent parameters :math:`\bm\theta_\ell\in\mathbb{R}^m`, :math:`m\in\mathbb{N}`, while :math:`\mathbf{E}_\mathrm{meas} \sim \mathcal{N}(\mathbf{0}, \mathrm{diag}(\sigma_m))`, :math:`\sigma_m\in\mathbb{R}_+` describes an independent and identical distributed (i.i.d.) measurement error. The alternative to the additive model prediction error is a multiplicative one. In this case, Expression :ref:`(1) <eq:1>` is specified to
+Here, :math:`\mathbf{E}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) \sim \mathcal{N}(\mathbf{0}, \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell))` denotes a Gaussian model for the prediction error, introducing additional latent parameters :math:`\bm\theta_\ell\in\mathbb{R}^m`, :math:`m\in\mathbb{N}`, while :math:`\mathbf{E}_\mathrm{meas} \sim \mathcal{N}(\mathbf{0}, \mathrm{diag}(\sigma_m^2))`, :math:`\sigma_m\in\mathbb{R}_+` describes an independent and identical distributed (i.i.d.) measurement error. The alternative to the additive model prediction error is a multiplicative one. In this case, Expression :ref:`(1) <eq:1>` is specified to
 
 .. math::
     :name: eq:3
 
     \mathbf{Y}_e =  \mathbf{K}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell)\mathbf{y}(\mathbf{x}_e,\bm\theta_y) + \mathbf{E}_\mathrm{meas}
 
-where  :math:`\mathbf{K}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) \sim \mathcal{N}(\mathbf{1}, \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell))` denotes the unit-mean prediction error while :math:`\mathbf{E}_\mathrm{meas} \sim \mathcal{N}(\mathbf{0}, \mathrm{diag}(\sigma_m))` describes the measurement error as defined before. Both data generation processes, Equations :ref:`(2) <eq:2>` and :ref:`(3) <eq:3>`, describe a random variable following a multivariate normal distribution as given by :ref:`(1) <eq:1>` where the covariance matrix is given by
+where  :math:`\mathbf{K}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) \sim \mathcal{N}(\mathbf{1}, \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell))` denotes the unit-mean prediction error while :math:`\mathbf{E}_\mathrm{meas} \sim \mathcal{N}(\mathbf{0}, \mathrm{diag}(\sigma_m^2))` describes the measurement error as defined before. Both data generation processes, Equations :ref:`(2) <eq:2>` and :ref:`(3) <eq:3>`, describe a random variable following a multivariate normal distribution as given by :ref:`(1) <eq:1>` where the covariance matrix is given by
 
 .. math::
 
     \bm{\Sigma}(\mathbf{x}_e) = \begin{cases}
-        \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) + \mathrm{diag}(\sigma_m)  & \text{(additive)} \\
-        \mathrm{diag}(\mathbf{y}(\mathbf{x}_e,\bm\theta_y))\bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell)\mathrm{diag}(\mathbf{y}(\mathbf{x}_e,\bm\theta_y)) + \mathrm{diag}(\sigma_m) & \text{(multiplicative).}
+        \bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell) + \mathrm{diag}(\sigma_m^2)  & \text{(additive)} \\
+        \mathrm{diag}(\mathbf{y}(\mathbf{x}_e,\bm\theta_y))\bm{\Sigma}_\mathrm{model}(\mathbf{x}_e,\bm{\theta}_\ell)\mathrm{diag}(\mathbf{y}(\mathbf{x}_e,\bm\theta_y)) + \mathrm{diag}(\sigma_m^2) & \text{(multiplicative).}
         \end{cases}
 
 Once the mean vector :math:`\bm\mu(\mathbf{x}_e)` and the covariance matrix :math:`\bm{\Sigma}(\mathbf{x}_e)` are determined, the likelihood of the statistical model can be evaluated via

--- a/probeye/__init__.py
+++ b/probeye/__init__.py
@@ -1,3 +1,3 @@
 # this is the only place to define the package version; it is currently used by
 # setup.cfg, docs/conf.py and by the method print_probeye_header in subroutines.py
-__version__ = "3.0.2"
+__version__ = "3.0.3"

--- a/probeye/definition/forward_model.py
+++ b/probeye/definition/forward_model.py
@@ -22,15 +22,27 @@ class ForwardModelBase:
     name
         The name of the forward model. Must be unique among all forward model's names
         within a considered InverseProblem.
+    args
+        Additional positional arguments that might be passed to the forward model when
+        it is initialized.
+    kwargs
+        Additional keyword arguments that might be passed to the forward model when it
+        is initialized.
     """
 
     def __init__(
         self,
         name: str,
+        *args: tuple,
+        **kwargs: dict,
     ):
 
         # set the forward model's name
         self.name = name
+
+        # possibly additional arguments for initialization
+        self.args = args
+        self.kwargs = kwargs
 
         # this is just for consistency; values will be overwritten with the next command
         self.parameters = ["_self.parameters_not_set"]

--- a/probeye/definition/inverse_problem.py
+++ b/probeye/definition/inverse_problem.py
@@ -651,7 +651,9 @@ class InverseProblem:
 
         # add an instance of the forward model's hull (which contains its 'interface'-
         # method but not its 'response'-method) to the problem
-        fwd_model_hull = ForwardModelHull(forward_model.name)
+        fwd_model_hull = ForwardModelHull(
+            forward_model.name, *forward_model.args, **forward_model.kwargs
+        )
         fwd_model_hull.experiment_names = experiment_list
         self.forward_models[forward_model.name] = fwd_model_hull
 

--- a/probeye/inference/scipy/solver.py
+++ b/probeye/inference/scipy/solver.py
@@ -80,12 +80,14 @@ class ScipySolver(Solver):
         Translate the inverse problem's forward models as needed for this solver.
         """
         logger.debug("Translate the problem's forward models")
-        for fwd_name in self.problem.forward_models:
+        for fwd_name, fwd_obj in self.problem.forward_models.items():
 
             # create a full forward model from its hull where the sensors are not yet
             # connected to the experimental data
             forward_model_hull = self.problem.forward_models[fwd_name]
-            forward_model = forward_model_hull.__class__.__bases__[0](fwd_name)
+            forward_model = forward_model_hull.__class__.__bases__[0](
+                fwd_name, *fwd_obj.args, **fwd_obj.kwargs
+            )
             synchronize_objects(
                 forward_model,
                 forward_model_hull,


### PR DESCRIPTION
The forward model could not take additional positional or keyword arguments during init. However, this option might be very helpful, so I added this option. I also fixed an error in the docs.