### PR TITLE
97 the ci is failing

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -102,7 +102,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+          python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
       steps:
         - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,10 +7,10 @@ description = A general framework for setting up parameter estimation problems.
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
     Intended Audience :: Science/Research
     Operating System :: OS Independent
@@ -18,7 +18,7 @@ classifiers =
 license_files = LICENSE
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.7
 packages = find:
 include_package_data = True
 install_requires =


### PR DESCRIPTION
From [this link](https://github.com/actions/setup-python/issues/544#issuecomment-1332535877), they dropped support for python 3.6 on the runners, as it is also not supported in Ubuntu 22.04. We were already running python 3.7-3.10 in the push tests, so I updated the "latest" as well. Would there any reason to keep testing for python 3.6? It could be done by especifying to run it in Ubuntu 20.04, but I am not sure if that is desirable for us.