### PR TITLE
Update push.yaml to do latest with 3.10 correctly

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -102,7 +102,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+          python-version: [ "3.7", "3.8", "3.9", "3.10" ]
 
       steps:
         - uses: actions/checkout@v2


### PR DESCRIPTION
This is a merge request to update the version number correctly also for the latest tests.