### PR TITLE
103 output sensor order in forward model

### DIFF
--- a/probeye/inference/scipy/solver.py
+++ b/probeye/inference/scipy/solver.py
@@ -81,7 +81,6 @@ class ScipySolver(Solver):
         """
         logger.debug("Translate the problem's forward models")
         for fwd_name, fwd_obj in self.problem.forward_models.items():
-
             # create a full forward model from its hull where the sensors are not yet
             # connected to the experimental data
             forward_model_hull = self.problem.forward_models[fwd_name]
@@ -115,7 +114,6 @@ class ScipySolver(Solver):
 
         logger.debug("Translate the problem's likelihood models")
         for like_name in self.problem.likelihood_models:
-
             # the likelihood model's forward model is still referencing the old (i.e.,
             # not-translated) forward model and needs to be reset to the updated one
             fwd_name = self.problem.likelihood_models[like_name].forward_model.name
@@ -167,7 +165,9 @@ class ScipySolver(Solver):
         exp_response_dict = forward_model.output_from_experiments[experiment_name]
         # Reorder exmperiment response dict to match model response dict
         if not list(model_response_dict.keys()) == list(exp_response_dict.keys()):
-            exp_response_dict={key: exp_response_dict[key] for key in model_response_dict.keys()}
+            exp_response_dict = {
+                key: exp_response_dict[key] for key in model_response_dict.keys()
+            }
             forward_model.output_from_experiments[experiment_name] = exp_response_dict
         exp_response_vector = vectorize_numpy_dict(exp_response_dict)
         residuals_vector = exp_response_vector - model_response_vector

--- a/probeye/inference/scipy/solver.py
+++ b/probeye/inference/scipy/solver.py
@@ -165,6 +165,10 @@ class ScipySolver(Solver):
 
         # compute the residuals by comparing to the experimental response
         exp_response_dict = forward_model.output_from_experiments[experiment_name]
+        # Reorder exmperiment response dict to match model response dict
+        if not list(model_response_dict.keys()) == list(exp_response_dict.keys()):
+            exp_response_dict={key: exp_response_dict[key] for key in model_response_dict.keys()}
+            forward_model.output_from_experiments[experiment_name] = exp_response_dict
         exp_response_vector = vectorize_numpy_dict(exp_response_dict)
         residuals_vector = exp_response_vector - model_response_vector
 

--- a/tests/unit_tests/inference/scipy/test_solver.py
+++ b/tests/unit_tests/inference/scipy/test_solver.py
@@ -141,6 +141,75 @@ class TestProblem(unittest.TestCase):
         comp_result = scipy_solver.loglike(theta)
         self.assertEqual(comp_result, -np.infty)
 
+    def test_ordered_sensors(self):
+        def linearModel(par1, par2, pos) :
+            return pos * par1 + par2
+
+        # true parameter values
+        par1True = 42
+        par2True = 16
+
+        # correct forward model
+        class CorrectDummyModel(ForwardModelBase) :
+            def interface(self) :
+                self.parameters = ["par1", "par2"]
+                self.input_sensors= []
+                self.output_sensors= [
+                    Sensor("S1", std_model="sigma"),
+                    Sensor("S2", std_model="sigma"),
+                ]
+            
+            def response(self, inp: dict) :  
+                res1 = linearModel(inp['par1'], inp['par2'], 10)
+                res2 = linearModel(inp['par1'], inp['par2'], -10)
+                return {'S1' : res1, 'S2': res2, }
+
+        # incorrect forward model
+        class WrongDummyModel(ForwardModelBase) :
+            def interface(self) :
+                self.parameters = ["par1", "par2"]
+                self.input_sensors= []
+                self.output_sensors= [
+                    Sensor("S1", std_model="sigma"),
+                    Sensor("S2", std_model="sigma"),
+                ]
+            
+            def response(self, inp: dict) :
+                
+                res1 = linearModel(inp['par1'], inp['par2'], 10)
+                res2 = linearModel(inp['par1'], inp['par2'], -10)
+                
+                return {'S2': res2, 'S1' : res1, }
+
+        problem = InverseProblem('Linear problem', print_header=False)
+
+        problem.add_parameter("par1",prior=Uniform( low = -250.0, high = 250.0))
+        problem.add_parameter("par2",prior=Uniform( low = -100.0, high = 100.0),)
+        problem.add_parameter("sigma",value=0.01)
+        # experimental data 
+        res_test = dict()
+        res_test['S1'] = linearModel(par1True, par2True, 10)
+        res_test['S2'] = linearModel(par1True, par2True, -10)
+
+        problem.add_experiment(name='Correct',sensor_data= res_test)
+        problem.add_experiment(name='Wrong',sensor_data= res_test)
+        problem.add_forward_model(CorrectDummyModel("RM"), experiments = ["Correct"])
+        problem.add_forward_model(WrongDummyModel("WM"), experiments = ["Wrong"])
+
+        # likelihoods
+        problem.add_likelihood_model(
+            GaussianLikelihoodModel(experiment_name="Correct", model_error="additive")
+        )
+        problem.add_likelihood_model(
+            GaussianLikelihoodModel(experiment_name="Wrong", model_error="additive")
+        )
+        scipy_solver = MaxLikelihoodSolver(problem, show_progress=False)
+        max_like_data = scipy_solver.run( solver_options = {
+                                                            "maxiter" : 5000,
+                                                            "maxfev" : 10000,
+                                                            })
+        self.assertTrue(np.allclose(max_like_data.x, np.array([par1True, par2True, 0.01])))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added check for same sensor definition order in the scipy solvers beetween model and experiment response. If they are different, the experiment reponse dictionary is modified for the forward model, therefore it is only run during the first evaluation. Added test based on @ppp0l 's suggested MWE.