### PR TITLE
111 importerror cannot import name gaussian from scipysignal

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,7 +36,7 @@ jobs:
     needs: [ lint_and_type_check ]
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -104,7 +104,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11", "3.12"]
 
       steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,7 +3,9 @@
 name: CI
 
 on:
-  [push, workflow_dispatch]:
+  workflow_dispatch:
+  
+  push:
   schedule:
     - cron: '0 1 * * 6'  # weekly run at 01:00 UTC on Saturday, dependency check
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -3,7 +3,7 @@
 name: CI
 
 on:
-  push:
+  [push, workflow_dispatch]:
   schedule:
     - cron: '0 1 * * 6'  # weekly run at 01:00 UTC on Saturday, dependency check
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,6 @@ description = A general framework for setting up parameter estimation problems.
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -28,7 +26,7 @@ install_requires =
     matplotlib<4
     emcee<4
     tabulate<1
-    arviz>0.18.0
+    arviz<1
     loguru<1
     rdflib<7
     owlready2<1

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ classifiers =
 license_files = LICENSE
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     matplotlib<4
     emcee<4
     tabulate<1
-    arviz>0.18
+    arviz>0.18.0
     loguru<1
     rdflib<7
     owlready2<1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     matplotlib<4
     emcee<4
     tabulate<1
-    arviz<1
+    arviz>0.18
     loguru<1
     rdflib<7
     owlready2<1


### PR DESCRIPTION
The updated arviz version (required to be compatible with the new scipy version) requires at least python 3.10. Thus, all other versions have been removed (3.8 and 3.9).