### PR TITLE
Fixed CI for chaospy

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package with dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools==68.0.0 wheel
           pip install .[tests] 
       - name: Test with pytest
         run: |
@@ -118,7 +118,7 @@ jobs:
         - name: Install package with latest dependencies
           run: |
             python probeye/_setup_cfg.py
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools==68.0.0 wheel
             pip install .[tests]
         - name: Test with pytest
           run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,7 +38,7 @@ jobs:
     needs: [ lint_and_type_check ]
     strategy:
       matrix:
-        python-version: [ "3.10"]
+        python-version: [ "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2
@@ -107,7 +107,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: ["3.10"]
+          python-version: ["3.10", "3.11", "3.12"]
 
       steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -48,7 +48,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package with dependencies
         run: |
-          pip install .[tests]
+          python -m pip install --upgrade pip setuptools wheel
+          pip install .[tests] 
       - name: Test with pytest
         run: |
           # grab the coverage output and also print it to the sreen
@@ -117,6 +118,7 @@ jobs:
         - name: Install package with latest dependencies
           run: |
             python probeye/_setup_cfg.py
+            python -m pip install --upgrade pip setuptools wheel
             pip install .[tests]
         - name: Test with pytest
           run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,7 +38,7 @@ jobs:
     needs: [ lint_and_type_check ]
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11"]
+        python-version: [ "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -107,7 +107,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: ["3.10", "3.11"]
+          python-version: ["3.10"]
 
       steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,7 +38,7 @@ jobs:
     needs: [ lint_and_type_check ]
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12"]
+        python-version: [ "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package with dependencies
         run: |
-          python -m pip install --upgrade pip setuptools==68.0.0 wheel
+          python -m pip install --upgrade pip setuptools wheel
           pip install .[tests] 
       - name: Test with pytest
         run: |
@@ -107,7 +107,7 @@ jobs:
       needs: [ lint_and_type_check ]
       strategy:
         matrix:
-          python-version: ["3.10", "3.11", "3.12"]
+          python-version: ["3.10", "3.11"]
 
       steps:
         - uses: actions/checkout@v2
@@ -118,7 +118,7 @@ jobs:
         - name: Install package with latest dependencies
           run: |
             python probeye/_setup_cfg.py
-            python -m pip install --upgrade pip setuptools==68.0.0 wheel
+            python -m pip install --upgrade pip setuptools wheel
             pip install .[tests]
         - name: Test with pytest
           run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =
-    numpy==1.26.4
+    numpy<2
     scipy<2
     matplotlib<4
     emcee<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     dynesty
     tri-py<1
     numpoly>1.2.13
-    chaospy>4.13.16
+    chaospy
 
 [options.package_data]
 probeye = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =
-    numpy<1.20
+    numpy<2.0
     scipy<2
     matplotlib<4
     emcee<4
@@ -32,7 +32,8 @@ install_requires =
     owlready2<1
     dynesty
     tri-py<1
-    chaospy
+    numoly>1.2.13
+    chaospy=4.13.17
 
 [options.package_data]
 probeye = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     dynesty
     tri-py<1
     numpoly>1.2.13
-    chaospy
+    chaospy==4.3.18
 
 [options.package_data]
 probeye = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =
-    numpy<2.0
+    numpy==1.26.4
     scipy<2
     matplotlib<4
     emcee<4
@@ -32,8 +32,8 @@ install_requires =
     owlready2<1
     dynesty
     tri-py<1
-    numpoly>1.2.13
-    chaospy==4.3.18
+    numpoly==1.0.6
+    chaospy==3.3.9
 
 [options.package_data]
 probeye = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     owlready2<1
     dynesty
     tri-py<1
-    numoly>1.2.13
+    numpoly>1.2.13
     chaospy>4.13.16
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =
-    numpy<2
+    numpy<1.24
     scipy<2
     matplotlib<4
     emcee<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ python_requires = >= 3.10
 packages = find:
 include_package_data = True
 install_requires =
-    numpy<1.24
+    numpy<1.20
     scipy<2
     matplotlib<4
     emcee<4

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     dynesty
     tri-py<1
     numoly>1.2.13
-    chaospy=4.13.17
+    chaospy>4.13.16
 
 [options.package_data]
 probeye = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ install_requires =
     owlready2<1
     dynesty
     tri-py<1
-    numpoly==1.0.6
-    chaospy==3.3.9
+    numpoly<1.1
+    chaospy<3.4
 
 [options.package_data]
 probeye = 


### PR DESCRIPTION
It closes issue #122 by imposing restrictions on chaospy version. Higher versions trigger numpy incompatibilities. Supposedly solved in last chaospy implementation, but it is not reflected in the CI.